### PR TITLE
Feature/issue11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,18 @@
 ﻿name: CI
 
 on:
+  # CI sur PR et sur push des branches d'integration/stable.
   pull_request:
     branches: ["dev", "main"]
   push:
     branches: ["dev", "main"]
 
 jobs:
+  # Verification backend: syntaxe, import, init BDD et tests.
   backend-check:
     runs-on: ubuntu-latest
     services:
+      # Base postgres ephemere pour les tests backend en CI.
       postgres:
         image: postgres:16
         env:
@@ -54,6 +57,7 @@ jobs:
       - name: App import smoke test
         run: python -c "import main"
 
+      # Cree/actualise le schema avant les tests.
       - name: Initialize Database Schema
         run: |
           export PYTHONPATH=$PYTHONPATH:.
@@ -64,6 +68,7 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           pytest -q
 
+  # Build image backend si les checks backend sont au vert.
   docker-build-backend:
     runs-on: ubuntu-latest
     needs: backend-check
@@ -74,6 +79,7 @@ jobs:
       - name: Build backend image
         run: docker build -t marketplace-backend:sprint1 ./backend
 
+  # Verification frontend: installation, lint et build.
   frontend-check:
     runs-on: ubuntu-latest
     defaults:
@@ -99,6 +105,7 @@ jobs:
       - name: Build
         run: npm run build
 
+  # Build image frontend si les checks frontend sont au vert.
   docker-build-frontend:
     runs-on: ubuntu-latest
     needs: frontend-check

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -129,8 +129,22 @@ jobs:
   post-deploy-healthcheck:
     runs-on: ubuntu-latest
     needs: deploy-staging
-    if: ${{ secrets.STAGING_HEALTHCHECK_URL != '' }}
     steps:
-      - name: Healthcheck endpoint
+      - name: Skip if no healthcheck URL configured
+        id: check_url
+        env:
+          STAGING_HEALTHCHECK_URL: ${{ secrets.STAGING_HEALTHCHECK_URL }}
         run: |
-          curl -fsS "${{ secrets.STAGING_HEALTHCHECK_URL }}"
+          if [ -z "$STAGING_HEALTHCHECK_URL" ]; then
+            echo "STAGING_HEALTHCHECK_URL non defini, healthcheck ignore."
+            echo "has_url=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_url=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Healthcheck endpoint
+        if: ${{ steps.check_url.outputs.has_url == 'true' }}
+        env:
+          STAGING_HEALTHCHECK_URL: ${{ secrets.STAGING_HEALTHCHECK_URL }}
+        run: |
+          curl -fsS "$STAGING_HEALTHCHECK_URL"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,136 @@
+﻿name: Deploy Staging
+
+on:
+  # Trigger principal: une PR vers `dev` qui vient d'etre mergee.
+  pull_request:
+    branches: ["dev"]
+    types: [closed]
+  # Trigger secondaire: redeploiement manuel depuis l'onglet Actions.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # Build + push s'executent uniquement pour une PR mergee ou un lancement manuel.
+  build-and-push:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    outputs:
+      repo_lower: ${{ steps.vars.outputs.repo_lower }}
+      backend_image: ${{ steps.vars.outputs.backend_image }}
+      frontend_image: ${{ steps.vars.outputs.frontend_image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image variables
+        id: vars
+        shell: bash
+        run: |
+          # GHCR exige un nom de repository en minuscules.
+          REPO_LOWER="$(echo \"${GITHUB_REPOSITORY}\" | tr '[:upper:]' '[:lower:]')"
+
+          # Pour un trigger PR, on tag avec le commit de merge.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            IMAGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          else
+            IMAGE_SHA="${GITHUB_SHA}"
+          fi
+
+          echo "repo_lower=${REPO_LOWER}" >> "$GITHUB_OUTPUT"
+          echo "backend_image=ghcr.io/${REPO_LOWER}/backend:${IMAGE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "frontend_image=ghcr.io/${REPO_LOWER}/frontend:${IMAGE_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.backend_image }}
+            ghcr.io/${{ steps.vars.outputs.repo_lower }}/backend:dev-latest
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.frontend_image }}
+            ghcr.io/${{ steps.vars.outputs.repo_lower }}/frontend:dev-latest
+
+  # Deploiement sur l'hote staging via SSH + docker compose.
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Copy deployment files to staging host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_PORT || 22 }}
+          source: "docker-compose.staging.yml,data/schema/schema.sql"
+          target: ${{ secrets.STAGING_APP_DIR }}
+          overwrite: true
+
+      - name: Deploy on staging host
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          BACKEND_IMAGE: ${{ needs.build-and-push.outputs.backend_image }}
+          FRONTEND_IMAGE: ${{ needs.build-and-push.outputs.frontend_image }}
+          STAGING_ENV_FILE: ${{ secrets.STAGING_ENV_FILE }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_PORT || 22 }}
+          envs: BACKEND_IMAGE,FRONTEND_IMAGE,STAGING_ENV_FILE,GHCR_USERNAME,GHCR_TOKEN
+          script: |
+            set -e
+            # Dossier distant contenant compose + .env + schema.
+            APP_DIR="${{ secrets.STAGING_APP_DIR }}"
+            mkdir -p "$APP_DIR/data/schema"
+            cd "$APP_DIR"
+
+            # Mise a jour des variables d'environnement staging.
+            printf '%s\n' "$STAGING_ENV_FILE" > .env
+
+            # Login registry pour pull les images publiees juste avant.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+
+            # Pull puis redeploiement idempotent.
+            export BACKEND_IMAGE FRONTEND_IMAGE
+            docker compose -f docker-compose.staging.yml pull backend frontend
+            docker compose -f docker-compose.staging.yml up -d --remove-orphans
+
+  # Verification finale optionnelle si une URL de healthcheck est definie.
+  post-deploy-healthcheck:
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    if: ${{ secrets.STAGING_HEALTHCHECK_URL != '' }}
+    steps:
+      - name: Healthcheck endpoint
+        run: |
+          curl -fsS "${{ secrets.STAGING_HEALTHCHECK_URL }}"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,5 +1,5 @@
 ﻿services:
-  # Base de donnees locale pour developpement et tests.
+  # Base de donnees staging (persistante via volume).
   postgres:
     image: postgres:16-alpine
     container_name: marketplace_db
@@ -8,38 +8,33 @@
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      # Charge le schema SQL au premier demarrage du volume postgres.
+      # Initialise le schema au premier demarrage du volume.
       - ./data/schema/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
 
-  # API FastAPI locale (build depuis ./backend).
+  # API backend deployee depuis l'image publiee par GitHub Actions.
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
+    image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required}
     container_name: marketplace_api
     depends_on:
       postgres:
         condition: service_healthy
     env_file: .env
     environment:
-      # Prioritaire: URL de connexion complete pour SQLAlchemy.
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-      # Variable utilisee en fallback dans database.py.
       POSTGRES_HOST: postgres
     ports:
       - "8000:8000"
     restart: unless-stopped
 
-  # Frontend React servi par Nginx (build depuis ./frontend).
+  # Frontend deployee depuis l'image publiee par GitHub Actions.
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    image: ${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}
     container_name: marketplace_front
     depends_on:
       - backend
@@ -48,5 +43,5 @@
     restart: unless-stopped
 
 volumes:
-  # Conserve les donnees PostgreSQL entre les redemarrages.
+  # Conserve les donnees postgres entre redemarrages.
   postgres_data:

--- a/docs/devops_getting_started.md
+++ b/docs/devops_getting_started.md
@@ -20,6 +20,7 @@ docker compose up --build -d
 Services exposes :
 - API backend : `http://localhost:8000`
 - Documentation API : `http://localhost:8000/docs`
+- Frontend : `http://localhost:3000`
 - PostgreSQL : `localhost:5432`
 
 ## 3. Verifier l'etat des conteneurs
@@ -47,5 +48,3 @@ Le workflow `.github/workflows/ci.yml` lance :
 3. Smoke test d'import FastAPI
 4. Tests unitaires `pytest`
 5. Build Docker de l'image backend
-
-Pour finaliser GitFlow Sprint 1, configurer dans GitHub les protections de branches (`main`, `develop`) en suivant `docs/gitflow_pr_rules.md`.

--- a/docs/sprint2_cicd_staging.md
+++ b/docs/sprint2_cicd_staging.md
@@ -1,0 +1,76 @@
+﻿# Sprint 2 - Pipeline CI/CD vers Staging
+
+Ce document definit la mise en place du pipeline de deploiement staging pour le Sprint 2.
+
+## Objectif
+Automatiser le flux suivant apres merge/push sur `dev`:
+1. Build des images backend/frontend
+2. Push dans GHCR
+3. Deploiement sur un serveur cloud staging
+4. Healthcheck post-deploiement
+
+## Fichiers utilises
+- `.github/workflows/deploy-staging.yml`
+- `docker-compose.staging.yml`
+- `data/schema/schema.sql`
+
+## Secrets GitHub requis
+Configurer ces secrets dans le repo (Settings > Secrets and variables > Actions):
+- `STAGING_HOST`: IP ou DNS du serveur staging
+- `STAGING_USER`: utilisateur SSH
+- `STAGING_SSH_KEY`: cle privee SSH (format OpenSSH)
+- `STAGING_PORT`: port SSH (22 si non modifie)
+- `STAGING_APP_DIR`: dossier de deploiement distant (ex: `/opt/marketplace`)
+- `STAGING_ENV_FILE`: contenu complet du fichier `.env` staging (multi-lignes)
+- `GHCR_USERNAME`: utilisateur/compte autorise a pull sur GHCR
+- `GHCR_TOKEN`: token GHCR (read:packages minimum)
+- `STAGING_HEALTHCHECK_URL` (optionnel): URL verifiee apres deploiement (ex: `https://staging.example.com/api/v1/health`)
+
+## Variables a mettre dans STAGING_ENV_FILE
+Exemple minimal:
+```env
+POSTGRES_DB=marketplace_db
+POSTGRES_USER=marketplace_user
+POSTGRES_PASSWORD=change_me_staging
+POSTGRES_PORT=5432
+SECRET_KEY=change_me_super_secret
+ACCESS_TOKEN_EXPIRE_MINUTES=10080
+```
+
+## Workflow de deploiement
+Trigger:
+- fermeture de PR sur `dev` (deploiement uniquement si PR mergee)
+- execution manuelle (`workflow_dispatch`)
+
+Etapes:
+1. Build + push de 2 images versionnees par SHA
+2. Copie de `docker-compose.staging.yml` et `schema.sql` vers le serveur
+3. Creation/maj de `.env` sur le serveur
+4. `docker login ghcr.io`
+5. `docker compose pull` puis `docker compose up -d --remove-orphans`
+6. Healthcheck optionnel
+
+## Pre-requis serveur staging
+- Docker + Docker Compose plugin installes
+- Acces internet vers `ghcr.io`
+- utilisateur SSH autorise a executer docker
+- ports exposes:
+  - `3000` (frontend)
+  - `8000` (backend)
+  - `5432` (postgres, si conserve expose)
+
+## Rollback rapide
+Se connecter au serveur staging et redeployer une image precedente:
+```bash
+cd /opt/marketplace
+export BACKEND_IMAGE=ghcr.io/<org>/<repo>/backend:<ancien_sha>
+export FRONTEND_IMAGE=ghcr.io/<org>/<repo>/frontend:<ancien_sha>
+docker compose -f docker-compose.staging.yml up -d
+```
+
+## Points d'attention
+- Verifier que `GHCR_TOKEN` a bien l'autorisation de lecture de packages.
+- Si le healthcheck echoue, investiguer:
+  - `docker compose -f docker-compose.staging.yml ps`
+  - `docker compose -f docker-compose.staging.yml logs backend --tail=200`
+  - `docker compose -f docker-compose.staging.yml logs frontend --tail=200`


### PR DESCRIPTION
## Resume
- Ajout du pipeline CI/CD de deploiement vers staging (`.github/workflows/deploy-staging.yml`).
- Ajout d’un compose dedie staging (`docker-compose.staging.yml`) base sur images publiees.
- Ajout de la documentation Sprint 2 (`docs/sprint2_cicd_staging.md`).
- Commentaires ajoutés dans `docker-compose.yml` et `.github/workflows/ci.yml` pour lisibilite.
- Correction du healthcheck optionnel dans le workflow staging (suppression de l’usage invalide de `secrets` dans `if` job-level).

## Pourquoi
- Automatiser build/push/deploiement apres merge vers `dev`.
- Rendre les releases plus frequentes et plus fiables.
- Standardiser le deploiement staging pour l’equipe.

## Perimetre
- [x] Backend
- [x] Frontend
- [ ] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] `docker compose -f docker-compose.yml config` OK
- [x] `docker compose -f docker-compose.staging.yml config` OK (avec `BACKEND_IMAGE`/`FRONTEND_IMAGE`)
- [x] Workflow YAML corrige pour eviter l’erreur de parsing (`Unrecognized named-value: 'secrets'`)
- [ ] Run complet staging valide sur GitHub Actions (a verifier apres merge + secrets configures)
- [x] Aucun secret commit

## Sprint / Story
- Sprint : 2
- Story/Tache : Pipeline CI/CD vers environnement cloud staging/dev

## Notes pour la review
- Verifier la coherence de branche cible: `dev` (workflow CI/CD et docs alignes).
- Verifier les secrets GitHub requis:
  - `STAGING_HOST`
  - `STAGING_USER`
  - `STAGING_SSH_KEY`
  - `STAGING_PORT`
  - `STAGING_APP_DIR`
  - `STAGING_ENV_FILE`
  - `GHCR_USERNAME`
  - `GHCR_TOKEN`
  - `STAGING_HEALTHCHECK_URL` (optionnel)
- Verifier que l’environnement GitHub `staging` existe.
