### PR TITLE
feat #16: ajouter un accès SQL read-only et mettre à jour les scripts…

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -89,7 +89,7 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_PORT || 22 }}
-          source: "docker-compose.staging.yml,data/schema/schema.sql"
+          source: "docker-compose.staging.yml,data/schema/schema.sql,data/schema/002_clustering_tables.sql,data/schema/003_anomaly_tables.sql,data/schema/004_readonly_access.sql"
           target: ${{ secrets.STAGING_APP_DIR }}
           overwrite: true
 

--- a/data/schema/004_readonly_access.sql
+++ b/data/schema/004_readonly_access.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- Marketplace Locale Intelligente - Acces SQL read-only
+-- Auteur   : Yohann (DevOps/SRE)
+-- Objectif : Mettre a disposition un acces SQL en lecture seule pour l'equipe
+--            data (analyse/BI) sans risque de modification.
+-- =============================================================================
+
+DO
+$$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_roles
+        WHERE rolname = 'data_readonly'
+    ) THEN
+        CREATE ROLE data_readonly LOGIN PASSWORD 'change_me_data_readonly';
+    END IF;
+END
+$$;
+
+-- Acces a la base cible.
+GRANT CONNECT ON DATABASE marketplace_db TO data_readonly;
+
+-- Acces au schema applicatif.
+GRANT USAGE ON SCHEMA public TO data_readonly;
+REVOKE CREATE ON SCHEMA public FROM data_readonly;
+
+-- Lecture sur tout l'existant (tables + vues + sequences).
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO data_readonly;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO data_readonly;
+
+-- Lecture automatique sur les futurs objets.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT SELECT ON TABLES TO data_readonly;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+GRANT USAGE, SELECT ON SEQUENCES TO data_readonly;

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -10,6 +10,9 @@
       - postgres_data:/var/lib/postgresql/data
       # Initialise le schema au premier demarrage du volume.
       - ./data/schema/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ./data/schema/002_clustering_tables.sql:/docker-entrypoint-initdb.d/02_clustering.sql:ro
+      - ./data/schema/003_anomaly_tables.sql:/docker-entrypoint-initdb.d/03_anomalies.sql:ro
+      - ./data/schema/004_readonly_access.sql:/docker-entrypoint-initdb.d/04_readonly_access.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@
       - ./data/schema/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
       - ./data/schema/002_clustering_tables.sql:/docker-entrypoint-initdb.d/02_clustering.sql:ro
       - ./data/schema/003_anomaly_tables.sql:/docker-entrypoint-initdb.d/03_anomalies.sql:ro
+      - ./data/schema/004_readonly_access.sql:/docker-entrypoint-initdb.d/04_readonly_access.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s

--- a/docs/sprint3_data_access.md
+++ b/docs/sprint3_data_access.md
@@ -1,0 +1,60 @@
+# Sprint 3 - Mise a disposition des donnees (SQL read-only + API)
+
+## Objectif
+Fournir un acces aux donnees via:
+1. SQL en lecture seule (pour Power BI / analyses ad hoc)
+2. API analytique (pour integration applicative / scripts)
+
+## Livrables implementes
+- Script SQL read-only: `data/schema/004_readonly_access.sql`
+- Compose local/staging mis a jour pour charger ce script au bootstrap postgres
+- Workflow staging mis a jour pour copier tous les scripts schema (01 a 04)
+
+## 1) Acces SQL read-only
+
+### Role SQL cree
+- Role: `data_readonly`
+- Type: `LOGIN` + lecture seule
+- Permissions:
+  - `CONNECT` sur `marketplace_db`
+  - `USAGE` schema `public`
+  - `SELECT` sur toutes les tables et vues existantes
+  - `USAGE, SELECT` sur sequences
+  - `ALTER DEFAULT PRIVILEGES` pour conserver la lecture seule sur les futurs objets
+
+### Test rapide SQL
+```sql
+-- Connexion avec data_readonly
+SELECT current_user;
+
+-- Lecture OK
+SELECT COUNT(*) FROM users;
+SELECT * FROM v_sales_summary LIMIT 10;
+
+-- Ecriture KO (attendu)
+INSERT INTO users (email, password_hash, role, first_name, last_name)
+VALUES ('test@example.com', 'x', 'client', 'A', 'B');
+```
+
+## 2) Acces API analytique
+
+Endpoints exposes par le backend:
+- `GET /api/v1/data/sales-metrics`
+- `GET /api/v1/data/clustering/customers?limit=200`
+- `GET /api/v1/data/anomalies?limit=100`
+
+### Exemples
+```bash
+curl http://localhost:8000/api/v1/data/sales-metrics
+curl "http://localhost:8000/api/v1/data/clustering/customers?limit=50"
+curl "http://localhost:8000/api/v1/data/anomalies?limit=50"
+```
+
+## 3) Notes d'exploitation
+- Le script SQL read-only est execute au premier demarrage postgres du volume.
+- Si le volume postgres existe deja, il faut appliquer le script manuellement ou recreer le volume:
+```bash
+docker compose down -v
+docker compose up -d
+```
+- En staging, les scripts schema sont copies par `deploy-staging.yml` dans `${STAGING_APP_DIR}/data/schema/`.


### PR DESCRIPTION
## Resume
- Ajout d’un acces SQL read-only pour l’equipe data via un script schema dedie.
- Integration du script read-only dans les stacks Docker locale et staging.
- Mise a jour du workflow de deploiement staging pour copier tous les scripts schema necessaires.
- Ajout d’une documentation Sprint 3 sur la mise a disposition des donnees via SQL et API.

## Pourquoi
- Satisfaire l’exigence projet: fournir un acces aux donnees via SQL ou API.
- Permettre a l’equipe data (analyse/BI) de consulter les donnees sans risque de modification.
- Aligner local et staging pour eviter les ecarts de comportement.

## Perimetre
- [x] Backend
- [ ] Frontend
- [x] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] `docker compose -f docker-compose.yml config` OK
- [x] `docker compose -f docker-compose.staging.yml config` OK (avec `BACKEND_IMAGE`/`FRONTEND_IMAGE`)
- [x] Script SQL read-only ajoute et branche dans les init scripts postgres
- [x] Workflow staging met a jour pour copier `schema.sql` + `002` + `003` + `004`
- [ ] Validation run complet sur staging (a verifier apres deploiement)
- [x] Aucun secret commit

## Sprint / Story
- Sprint : 3
- Story/Tache : Mise a disposition des donnees via SQL read-only et API pour l’equipe data

## Notes pour la review
- Fichier ajoute:
  - `data/schema/004_readonly_access.sql`
  - `docs/sprint3_data_access.md`
- Fichiers modifies:
  - `docker-compose.yml`
  - `docker-compose.staging.yml`
  - `.github/workflows/deploy-staging.yml`
- Le role SQL cree: `data_readonly` (lecture seule).
- Pensee exploitation:
  - sur une DB deja initialisee, il faut soit appliquer le script manuellement, soit recreer le volume postgres.
- Point de securite a traiter en environnement reel:
  - changer le mot de passe par defaut du role `data_readonly`.
