### PR TITLE
feat #17: add Prometheus/Grafana observability stack and SRE dashboards

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -89,7 +89,7 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           port: ${{ secrets.STAGING_PORT || 22 }}
-          source: "docker-compose.staging.yml,data/schema/schema.sql,data/schema/002_clustering_tables.sql,data/schema/003_anomaly_tables.sql,data/schema/004_readonly_access.sql"
+          source: "docker-compose.staging.yml,monitoring,data/schema/schema.sql,data/schema/002_clustering_tables.sql,data/schema/003_anomaly_tables.sql,data/schema/004_readonly_access.sql"
           target: ${{ secrets.STAGING_APP_DIR }}
           overwrite: true
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -45,6 +45,46 @@
       - "3000:80"
     restart: unless-stopped
 
+  # Prometheus collecte les metriques exposees par l'API staging.
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: marketplace_prometheus
+    depends_on:
+      - backend
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  # Grafana staging pour dashboards SRE (error budget, SLO, latence).
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: marketplace_grafana
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3001:3000"
+    restart: unless-stopped
+
 volumes:
   # Conserve les donnees postgres entre redemarrages.
   postgres_data:
+  # Conserve les metriques Prometheus.
+  prometheus_data:
+  # Conserve les donnees internes Grafana.
+  grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,46 @@
       - "3000:80"
     restart: unless-stopped
 
+  # Prometheus collecte les metriques exposees par le backend (/metrics).
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: marketplace_prometheus
+    depends_on:
+      - backend
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  # Grafana visualise les metriques Prometheus via dashboards provisionnes.
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: marketplace_grafana
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3001:3000"
+    restart: unless-stopped
+
 volumes:
   # Conserve les donnees PostgreSQL entre les redemarrages.
   postgres_data:
+  # Conserve les metriques Prometheus.
+  prometheus_data:
+  # Conserve la base interne Grafana (users, prefs, etc.).
+  grafana_data:

--- a/docs/sprint3_observability_stack.md
+++ b/docs/sprint3_observability_stack.md
@@ -1,0 +1,142 @@
+# Sprint 3 - Stack Observabilite Prometheus + Grafana
+
+## Objectif
+Mettre en place une supervision centralisee pour:
+- suivre la sante technique du backend,
+- visualiser les indicateurs SRE (latence, disponibilite, erreurs),
+- observer la consommation de l'error budget.
+
+## Livrables implementes
+- Stack monitoring ajoutee dans:
+  - `docker-compose.yml`
+  - `docker-compose.staging.yml`
+- Configuration Prometheus:
+  - `monitoring/prometheus/prometheus.yml`
+- Provisioning Grafana:
+  - `monitoring/grafana/provisioning/datasources/prometheus.yml`
+  - `monitoring/grafana/provisioning/dashboards/dashboards.yml`
+- Dashboards SRE pre-provisionnes:
+  - `monitoring/grafana/dashboards/sre_api_overview.json`
+  - `monitoring/grafana/dashboards/sre_error_budget.json`
+- Workflow staging mis a jour pour copier `monitoring/`:
+  - `.github/workflows/deploy-staging.yml`
+
+## Metriques sources
+Le backend expose deja `/metrics` avec:
+- `http_requests_total`
+- `http_requests_success_total`
+- `http_requests_error_total`
+- `http_request_duration_seconds` (histogram)
+
+## Dashboards fournis
+### 1) Marketplace SRE - API Overview
+- Disponibilite API (5m)
+- Latence p90 `POST /api/v1/orders`
+- Taux erreur `POST /api/v1/payments`
+- Trafic HTTP par route/status
+
+### 2) Marketplace SRE - Error Budget & SLO
+- Consommation error budget (base SLO 99.5%)
+- Disponibilite vs SLO cible
+- SLO latence commandes (300ms)
+- SLO erreurs paiements (0.1%)
+
+## Lancement en local
+```bash
+docker compose up -d --build
+```
+
+Acces:
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3001`
+  - login par defaut: `admin / admin` (modifiable via `.env`)
+
+Variables optionnelles:
+```env
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+```
+
+## Deploiement staging
+Le workflow staging copie `monitoring/` sur le serveur et lance les services Prometheus/Grafana via `docker-compose.staging.yml`.
+
+Ports staging attendus:
+- `9090` (Prometheus)
+- `3001` (Grafana)
+
+## Verification rapide
+1. Ouvrir Grafana et verifier la presence du dossier `Marketplace SRE`.
+2. Verifier que la datasource Prometheus est `Healthy`.
+3. Verifier que Prometheus scrape bien `backend:8000/metrics`.
+
+## Procedure de test recommandee (local)
+### 1) Verifier l'etat des services
+```powershell
+docker compose ps
+```
+Les services `backend`, `prometheus` et `grafana` doivent etre `Up`.
+
+### 2) Verifier l'exposition des metriques backend
+```powershell
+Invoke-WebRequest http://localhost:8000/metrics | Select-Object -ExpandProperty Content
+```
+La sortie doit contenir des metriques comme:
+- `http_requests_total`
+- `http_requests_success_total`
+- `http_request_duration_seconds_bucket`
+
+### 3) Verifier les targets Prometheus
+- Ouvrir `http://localhost:9090/targets`
+- Les jobs `marketplace-backend` et `prometheus` doivent etre `UP`.
+
+### 4) Generer du trafic pour remplir les dashboards
+Sans trafic, certains panneaux restent a `No data` ou retombent a `0%` (fenetre glissante `rate(...[5m])`).
+
+Exemple PowerShell:
+```powershell
+for ($i=0; $i -lt 20; $i++) {
+  try {
+    Invoke-WebRequest -Uri "http://localhost:8000/api/v1/data/sales-metrics" -Method GET | Out-Null
+  } catch {}
+  Start-Sleep -Milliseconds 200
+}
+```
+
+Pour tester la latence `POST /api/v1/orders`, il faut appeler cette route avec un payload valide.
+Pour tester le taux d'erreur `POST /api/v1/payments`, il faut appeler cette route (avec ou sans auth selon le scenario voulu).
+
+### 5) Verifier Grafana
+- Ouvrir `http://localhost:3001`
+- Dashboard `Marketplace SRE - API Overview`
+- Dashboard `Marketplace SRE - Error Budget & SLO`
+- Choisir une fenetre recente (`Last 15 minutes`) et rafraichir.
+
+## Interpretation des valeurs
+- `No data`: pas assez de points pour la requete (souvent pas de trafic sur la route cible).
+- `0%` sur disponibilite/taux erreur: possible quand il n'y a plus de trafic recent.
+- Valeurs qui changent vite: normal avec peu de requetes et une fenetre `[5m]`.
+- `401` sur `/api/v1/payments`: compte comme erreur metier dans le dashboard actuel (4xx/5xx).
+
+## Depannage rapide
+### Dashboards absents dans Grafana
+1. Verifier les fichiers JSON dans `monitoring/grafana/dashboards/`.
+2. Redemarrer Grafana:
+```powershell
+docker compose restart grafana
+```
+3. Verifier les logs:
+```powershell
+docker compose logs grafana --tail=200
+```
+
+### Prometheus ne scrape pas backend
+1. Verifier `monitoring/prometheus/prometheus.yml`.
+2. Verifier les logs:
+```powershell
+docker compose logs prometheus --tail=200
+```
+3. Redemarrer Prometheus:
+```powershell
+docker compose restart prometheus
+```
+

--- a/monitoring/grafana/dashboards/sre_api_overview.json
+++ b/monitoring/grafana/dashboards/sre_api_overview.json
@@ -1,0 +1,178 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "orange", "value": 99},
+              {"color": "green", "value": 99.5}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "100 * sum(increase(http_requests_success_total[1h])) / clamp_min(sum(increase(http_requests_total[1h])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Disponibilite API (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.2},
+              {"color": "red", "value": 0.3}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, sum(increase(http_request_duration_seconds_bucket{method=\"POST\",path=\"/api/v1/orders\"}[1h])) by (le))",
+          "refId": "A"
+        }
+      ],
+      "title": "Latence p90 POST /api/v1/orders",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.05},
+              {"color": "red", "value": 0.1}
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"4..|5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Taux erreur POST /api/v1/payments",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 8},
+      "id": 4,
+      "options": {"legend": {"showLegend": true}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "expr": "sum by (path, status_code) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{path}} {{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Trafic HTTP par route et code",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["sre", "api", "prometheus"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Marketplace SRE - API Overview",
+  "uid": "marketplace-sre-api-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/dashboards/sre_error_budget.json
+++ b/monitoring/grafana/dashboards/sre_error_budget.json
@@ -1,0 +1,156 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 50},
+              {"color": "red", "value": 80}
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "100 * (1 - (sum(increase(http_requests_success_total[24h])) / clamp_min(sum(increase(http_requests_total[24h])), 1))) / (1 - 0.995)",
+          "refId": "A"
+        }
+      ],
+      "title": "Consommation Error Budget (SLO 99.5%)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 16, "x": 8, "y": 0},
+      "id": 2,
+      "options": {"legend": {"showLegend": true}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "expr": "100 * sum(increase(http_requests_success_total[1h])) / clamp_min(sum(increase(http_requests_total[1h])), 1)",
+          "legendFormat": "Disponibilite API",
+          "refId": "A"
+        },
+        {
+          "expr": "99.5",
+          "legendFormat": "SLO cible",
+          "refId": "B"
+        }
+      ],
+      "title": "Disponibilite vs SLO",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "options": {"legend": {"showLegend": true}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, sum(increase(http_request_duration_seconds_bucket{method=\"POST\",path=\"/api/v1/orders\"}[1h])) by (le))",
+          "legendFormat": "Latence p90",
+          "refId": "A"
+        },
+        {
+          "expr": "0.3",
+          "legendFormat": "SLO 300ms",
+          "refId": "B"
+        }
+      ],
+      "title": "SLO latence commandes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "options": {"legend": {"showLegend": true}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"4..|5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
+          "legendFormat": "Taux erreur paiements",
+          "refId": "A"
+        },
+        {
+          "expr": "0.001",
+          "legendFormat": "SLO erreur 0.1%",
+          "refId": "B"
+        }
+      ],
+      "title": "SLO erreurs paiements",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["sre", "error-budget", "slo"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Marketplace SRE - Error Budget & SLO",
+  "uid": "marketplace-sre-error-budget",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+﻿apiVersion: 1
+
+providers:
+  - name: Marketplace SRE Dashboards
+    orgId: 1
+    folder: Marketplace SRE
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+﻿apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+﻿global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: marketplace-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["backend:8000"]


### PR DESCRIPTION
## Resume
- Mise en place de la stack observabilite Sprint 3:
  - Ajout de Prometheus + Grafana dans `docker-compose.yml` et `docker-compose.staging.yml`
  - Ajout du provisioning Grafana (datasource + dashboards)
  - Ajout des dashboards SRE:
    - `Marketplace SRE - API Overview`
    - `Marketplace SRE - Error Budget & SLO`
  - MAJ du workflow staging pour copier le dossier `monitoring/`
  - Documentation de mise en place, tests et debug dans `docs/sprint3_observability_stack.md`
- Ajustement des requetes PromQL pour des resultats plus stables/visibles avec trafic faible.

## Pourquoi
- Centraliser la supervision technique (Prometheus + Grafana)
- Suivre les indicateurs SRE (disponibilite, latence, taux d'erreur, error budget)
- Repondre a la tache Sprint 3: stack observabilite + suivi SLI/SLO exploitable

## Perimetre
- [ ] Backend
- [ ] Frontend
- [ ] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] Verifications locales executees
- [ ] CI au vert
- [x] Aucun secret commit

## Sprint / Story
- Sprint : 3
- Story/Tache : Stack observabilite Prometheus + Grafana avec dashboards SRE

## Notes pour la review
- Points a verifier en priorite :
  - Les services `prometheus` et `grafana` montent bien en local/staging
  - Les targets Prometheus sont `UP` (`backend:8000/metrics`, `prometheus:9090`)
  - Les dashboards Grafana se provisionnent automatiquement
  - Les panneaux affichent des valeurs apres generation de trafic de test
  - Le workflow staging copie bien `monitoring/` sur le serveur
