### PR TITLE
feat #18: formalize SLI/SLO/SLA and add Prometheus rules/alerts

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -53,6 +53,7 @@
       - backend
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/sli_slo_rules.yml:/etc/prometheus/rules/sli_slo_rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@
       - backend
     volumes:
       - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/sli_slo_rules.yml:/etc/prometheus/rules/sli_slo_rules.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"

--- a/docs/sprint3_observability_stack.md
+++ b/docs/sprint3_observability_stack.md
@@ -30,7 +30,7 @@ Le backend expose deja `/metrics` avec:
 
 ## Dashboards fournis
 ### 1) Marketplace SRE - API Overview
-- Disponibilite API (5m)
+- Disponibilite API (1h)
 - Latence p90 `POST /api/v1/orders`
 - Taux erreur `POST /api/v1/payments`
 - Trafic HTTP par route/status
@@ -90,7 +90,7 @@ La sortie doit contenir des metriques comme:
 - Les jobs `marketplace-backend` et `prometheus` doivent etre `UP`.
 
 ### 4) Generer du trafic pour remplir les dashboards
-Sans trafic, certains panneaux restent a `No data` ou retombent a `0%` (fenetre glissante `rate(...[5m])`).
+Sans trafic, certains panneaux peuvent rester a `No data` ou retomber a `0%`.
 
 Exemple PowerShell:
 ```powershell
@@ -114,8 +114,8 @@ Pour tester le taux d'erreur `POST /api/v1/payments`, il faut appeler cette rout
 ## Interpretation des valeurs
 - `No data`: pas assez de points pour la requete (souvent pas de trafic sur la route cible).
 - `0%` sur disponibilite/taux erreur: possible quand il n'y a plus de trafic recent.
-- Valeurs qui changent vite: normal avec peu de requetes et une fenetre `[5m]`.
-- `401` sur `/api/v1/payments`: compte comme erreur metier dans le dashboard actuel (4xx/5xx).
+- Valeurs qui changent vite: normal avec peu de requetes.
+- Le taux d'erreurs paiements suit les erreurs techniques `5xx` (pas les `401`).
 
 ## Depannage rapide
 ### Dashboards absents dans Grafana
@@ -140,3 +140,6 @@ docker compose logs prometheus --tail=200
 docker compose restart prometheus
 ```
 
+## Lien avec la formalisation SLI/SLO/SLA
+La politique d'exploitation SRE (SLI, SLO, SLA, error budget, alertes Prometheus) est detaillee dans:
+- `docs/sprint3_sli_slo_sla.md`

--- a/docs/sprint3_sli_slo_sla.md
+++ b/docs/sprint3_sli_slo_sla.md
@@ -1,0 +1,78 @@
+# Sprint 3 - Definition et suivi SLI/SLO/SLA
+
+## Objectif
+Formaliser une politique SRE exploitable pour la prise de decision en exploitation:
+- definition claire des SLI,
+- objectifs SLO mesurables,
+- cadre SLA,
+- regles de pilotage par error budget.
+
+## SLI retenus
+1. **Disponibilite API**
+- Definition: part des requetes considerees en succes applicatif.
+- Metrique: `http_requests_success_total / http_requests_total`
+- Fenetres de suivi:
+  - court terme: 1h
+  - budget: 24h
+
+2. **Latence commandes**
+- Definition: p90 de `POST /api/v1/orders`.
+- Metrique: `http_request_duration_seconds_bucket` (histogram).
+- Fenetre de suivi: 1h.
+
+3. **Taux d'erreurs techniques paiements**
+- Definition: taux de `5xx` sur `POST /api/v1/payments`.
+- Metrique: `http_requests_total{status_code=~"5.."}` / total paiements.
+- Fenetre de suivi: 1h.
+
+## SLO cibles
+1. Disponibilite API >= **99.5%**
+2. Latence p90 commandes <= **300 ms**
+3. Taux d'erreurs techniques paiements <= **0.1%**
+
+## SLA (cadre equipe/projet)
+SLA interne aligne au sujet:
+- engagement de fiabilite fonde sur les SLO,
+- suivi continu via dashboards Grafana et alertes Prometheus,
+- arbitrage release pilote par error budget.
+
+## Error budget et regles de release
+Error budget API:
+- Budget autorise = `1 - SLO` = `0.5%` d'indisponibilite.
+- Indicateur: `error_budget:api_consumed_ratio_24h`.
+
+Politique d'exploitation:
+1. **< 50% budget consomme**
+- cadence normale de livraison.
+2. **50% a 100%**
+- releases prudentes (petits lots, surveillance renforcee).
+3. **> 100%**
+- freeze des releases de fonctionnalites,
+- priorite aux correctifs de stabilite et reduction de dette technique.
+
+## Mise en oeuvre technique
+### Regles Prometheus
+Fichier:
+- `monitoring/prometheus/sli_slo_rules.yml`
+
+Contenu:
+- recording rules:
+  - `sli:api_availability_ratio_1h`
+  - `sli:api_availability_ratio_24h`
+  - `sli:orders_latency_p90_seconds_1h`
+  - `sli:payments_error_ratio_1h`
+  - `error_budget:api_consumed_ratio_24h`
+- alerting rules:
+  - `ApiAvailabilityBelowSLO`
+  - `OrdersLatencyAboveSLO`
+  - `Payments5xxErrorRateAboveSLO`
+  - `ErrorBudgetConsumptionHigh`
+
+### Config Prometheus
+- `monitoring/prometheus/prometheus.yml` charge:
+  - `/etc/prometheus/rules/sli_slo_rules.yml`
+
+### Compose local et staging
+Le fichier de regles est monte dans:
+- `docker-compose.yml`
+- `docker-compose.staging.yml`

--- a/monitoring/grafana/dashboards/sre_api_overview.json
+++ b/monitoring/grafana/dashboards/sre_api_overview.json
@@ -132,7 +132,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"4..|5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
+          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
           "refId": "A"
         }
       ],

--- a/monitoring/grafana/dashboards/sre_error_budget.json
+++ b/monitoring/grafana/dashboards/sre_error_budget.json
@@ -127,7 +127,7 @@
       "options": {"legend": {"showLegend": true}, "tooltip": {"mode": "single"}},
       "targets": [
         {
-          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"4..|5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
+          "expr": "sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\",status_code=~\"5..\"}[1h])) / clamp_min(sum(increase(http_requests_total{method=\"POST\",path=\"/api/v1/payments\"}[1h])), 1)",
           "legendFormat": "Taux erreur paiements",
           "refId": "A"
         },

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -2,6 +2,9 @@
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/sli_slo_rules.yml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/monitoring/prometheus/sli_slo_rules.yml
+++ b/monitoring/prometheus/sli_slo_rules.yml
@@ -1,0 +1,81 @@
+groups:
+  - name: marketplace_sli_recording
+    rules:
+      - record: sli:api_availability_ratio_1h
+        expr: |
+          sum(increase(http_requests_success_total[1h]))
+          /
+          clamp_min(sum(increase(http_requests_total[1h])), 1)
+
+      - record: sli:api_availability_ratio_24h
+        expr: |
+          sum(increase(http_requests_success_total[24h]))
+          /
+          clamp_min(sum(increase(http_requests_total[24h])), 1)
+
+      - record: sli:orders_latency_p90_seconds_1h
+        expr: |
+          histogram_quantile(0.90, sum(increase(http_request_duration_seconds_bucket{method="POST",path="/api/v1/orders"}[1h])) by (le))
+
+      - record: sli:payments_error_ratio_1h
+        expr: |
+          sum(increase(http_requests_total{method="POST",path="/api/v1/payments",status_code=~"5.."}[1h]))
+          /
+          clamp_min(sum(increase(http_requests_total{method="POST",path="/api/v1/payments"}[1h])), 1)
+
+      - record: slo:api_availability_target_ratio
+        expr: 0.995
+
+      - record: slo:orders_latency_target_seconds
+        expr: 0.3
+
+      - record: slo:payments_error_target_ratio
+        expr: 0.001
+
+      - record: error_budget:api_consumed_ratio_24h
+        expr: |
+          (1 - sli:api_availability_ratio_24h)
+          /
+          (1 - slo:api_availability_target_ratio)
+
+  - name: marketplace_slo_alerts
+    rules:
+      - alert: ApiAvailabilityBelowSLO
+        expr: sli:api_availability_ratio_1h < slo:api_availability_target_ratio
+        for: 10m
+        labels:
+          severity: warning
+          team: sre
+        annotations:
+          summary: "Disponibilite API sous le SLO (99.5%)"
+          description: "La disponibilite API sur 1h est sous l'objectif SLO de 99.5%."
+
+      - alert: OrdersLatencyAboveSLO
+        expr: sli:orders_latency_p90_seconds_1h > slo:orders_latency_target_seconds
+        for: 10m
+        labels:
+          severity: warning
+          team: sre
+        annotations:
+          summary: "Latence p90 des commandes au-dessus du SLO (300ms)"
+          description: "Le p90 de POST /api/v1/orders depasse 300ms sur 1h."
+
+      - alert: Payments5xxErrorRateAboveSLO
+        expr: sli:payments_error_ratio_1h > slo:payments_error_target_ratio
+        for: 10m
+        labels:
+          severity: warning
+          team: sre
+        annotations:
+          summary: "Taux d'erreurs techniques paiements au-dessus du SLO (0.1%)"
+          description: "Le taux 5xx sur POST /api/v1/payments depasse 0.1% sur 1h."
+
+      - alert: ErrorBudgetConsumptionHigh
+        expr: error_budget:api_consumed_ratio_24h > 1
+        for: 15m
+        labels:
+          severity: critical
+          team: sre
+        annotations:
+          summary: "Error budget API depasse"
+          description: "Le budget d'erreur API sur 24h est consomme a plus de 100%."


### PR DESCRIPTION
## Resume
- Formalisation complete de la tache Sprint 3 SLI/SLO/SLA en exploitation.
- Ajout des regles Prometheus (recording + alerting) pour suivre:
  - disponibilite API,
  - latence p90 commandes,
  - taux d'erreurs techniques paiements,
  - consommation error budget.
- Branchement des regles dans Prometheus et dans les compose local/staging.
- Alignement des dashboards Grafana sur erreurs techniques paiements (5xx).
- Mise a jour/normalisation de la documentation SRE.

## Pourquoi
- Rendre les objectifs de fiabilite actionnables (pas seulement theoriques).
- Permettre une prise de decision release basee sur l'error budget.

## Perimetre
- [ ] Backend
- [ ] Frontend
- [ ] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] Verifications locales executees
- [ ] CI au vert
- [x] Aucun secret commit

## Sprint / Story
- Sprint : 3
- Story/Tache : Definition et suivi des SLI/SLO/SLA dans l'exploitation

## Notes pour la review
- Points a verifier en priorite :
  - `monitoring/prometheus/sli_slo_rules.yml` charge correctement (Prometheus `/rules`)
  - alertes visibles dans Prometheus `/alerts`
  - dashboards Grafana SRE alimentes apres trafic de test
  - cohérence docs:
    - `docs/sprint3_sli_slo_sla.md`
    - `docs/sprint3_observability_stack.md`
