### PR TITLE
feat #23: ajouter des tests de charge k6 pour valider la performance …

### DIFF
--- a/docs/sprint4_load_tests_alerts.md
+++ b/docs/sprint4_load_tests_alerts.md
@@ -1,0 +1,65 @@
+# Sprint 4 - Tests de charge (k6) et verification des alertes SRE
+
+## Objectif
+Valider que:
+1. l'API tient sous charge raisonnable,
+2. les metriques SRE evoluent correctement,
+3. les alertes Prometheus se declenchent de facon attendue.
+
+## Perimetre
+- Outil: `k6`
+- Cible: API backend (`:8000`)
+- Observabilite:
+  - Prometheus (`/targets`, `/rules`, `/alerts`)
+  - Grafana (`Marketplace SRE - API Overview`, `Marketplace SRE - Error Budget & SLO`)
+
+## Scripts disponibles
+- `load-tests/k6/test_charge_01_smoke_endpoints_publics.js`
+- `load-tests/k6/test_charge_02_charge_nominale_mixte.js`
+- `load-tests/k6/test_charge_03_stress_paiements_5xx.js`
+
+## Prerequis
+1. Environnement disponible (local ou staging).
+2. Prometheus scrape bien `backend:8000/metrics`.
+3. k6 installe.
+
+## Campagne 
+### Smoke
+```bash
+k6 run -e BASE_URL=http://localhost:8000 load-tests/k6/test_charge_01_smoke_endpoints_publics.js
+```
+Attendu:
+- pas d'erreurs massives,
+- endpoint `/metrics` repond 200.
+
+### Charge nominale
+```bash
+k6 run -e BASE_URL=http://localhost:8000 load-tests/k6/test_charge_02_charge_nominale_mixte.js
+```
+Attendu:
+- dashboards Grafana alimentes,
+- evolution visible trafic/latence.
+
+### Stress erreurs techniques paiements
+```bash
+k6 run -e BASE_URL=http://localhost:8000 \
+  -e K6_CLIENT_EMAIL=client@test.local \
+  -e K6_CLIENT_PASSWORD=Test1234! \
+  -e K6_PRODUCT_ID=<uuid-produit> \
+  load-tests/k6/test_charge_03_stress_paiements_5xx.js
+```
+Attendu:
+- hausse `sli:payments_error_ratio_1h`,
+- alerte `Payments5xxErrorRateAboveSLO` qui passe `pending` puis `firing` si la condition tient > 10m.
+
+## Verification des alertes
+Pendant les tests:
+1. `http://<host>:9090/alerts`
+2. `http://<host>:9090/rules`
+3. Grafana dashboard SRE
+
+Alertes cibles:
+- `ApiAvailabilityBelowSLO`
+- `OrdersLatencyAboveSLO`
+- `Payments5xxErrorRateAboveSLO`
+- `ErrorBudgetConsumptionHigh`

--- a/load-tests/k6/README.md
+++ b/load-tests/k6/README.md
@@ -1,0 +1,65 @@
+# Tests de charge k6 - Sprint 4
+
+Ce dossier contient des scenarios k6 pour valider:
+- la tenue en charge de l'API,
+- la qualite des metriques Prometheus,
+- le declenchement des alertes SRE.
+
+## Prerequis
+- k6 installe localement.
+- Stack disponible (local ou staging):
+  - API (`:8000`)
+  - Prometheus (`:9090`)
+  - Grafana (`:3001`)
+
+## Variables utiles
+- `BASE_URL` (defaut: `http://localhost:8000`)
+- `K6_CLIENT_EMAIL` (optionnel)
+- `K6_CLIENT_PASSWORD` (optionnel)
+- `K6_PRODUCT_ID` (optionnel)
+
+## Scenarios
+1. `test_charge_01_smoke_endpoints_publics.js`
+- verification rapide de disponibilite globale.
+- cible endpoints publics.
+
+2. `test_charge_02_charge_nominale_mixte.js`
+- charge nominale mixte (public + commandes/paiements non authentifies).
+- utile pour verifier dashboards et tendances latence.
+
+3. `test_charge_03_stress_paiements_5xx.js`
+- scenario orienté erreurs techniques de paiement (`provider_timeout` / `network_error`).
+- sert a tester l'alerte `Payments5xxErrorRateAboveSLO`.
+- prefere fournir `K6_CLIENT_EMAIL`, `K6_CLIENT_PASSWORD`, `K6_PRODUCT_ID`.
+
+## Exemples de lancement
+```bash
+# smoke (2 min)
+k6 run load-tests/k6/test_charge_01_smoke_endpoints_publics.js
+
+# charge nominale (10 min)
+k6 run -e BASE_URL=http://localhost:8000 load-tests/k6/test_charge_02_charge_nominale_mixte.js
+
+# stress paiements techniques (15 min)
+k6 run -e BASE_URL=http://localhost:8000 \
+  -e K6_CLIENT_EMAIL=client@test.local \
+  -e K6_CLIENT_PASSWORD=Test1234! \
+  -e K6_PRODUCT_ID=<uuid-produit> \
+  load-tests/k6/test_charge_03_stress_paiements_5xx.js
+```
+
+## Verification alertes SRE
+Pendant le test:
+- Prometheus alerts: `http://<host>:9090/alerts`
+- Grafana dashboard SRE:
+  - `Marketplace SRE - API Overview`
+  - `Marketplace SRE - Error Budget & SLO`
+
+Alertes attendues selon scenario:
+- `ApiAvailabilityBelowSLO`
+- `OrdersLatencyAboveSLO` (si latence commandes degradee)
+- `Payments5xxErrorRateAboveSLO` (scenario paiements techniques)
+- `ErrorBudgetConsumptionHigh` (si budget depasse)
+
+Note:
+- Les alertes ont un `for` (10m/15m) dans Prometheus, donc il faut maintenir la pression suffisamment longtemps.

--- a/load-tests/k6/test_charge_01_smoke_endpoints_publics.js
+++ b/load-tests/k6/test_charge_01_smoke_endpoints_publics.js
@@ -1,0 +1,36 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+// URL cible de l'API.
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8000";
+
+// Scenario smoke: faible charge, verification rapide de disponibilite.
+export const options = {
+  vus: 5,
+  duration: "2m",
+  thresholds: {
+    // Moins de 5% d'echecs HTTP au global.
+    http_req_failed: ["rate<0.05"],
+    // Latence p95 sous 800ms pour un smoke.
+    http_req_duration: ["p(95)<800"],
+  },
+};
+
+export default function () {
+  // Endpoint racine de l'API.
+  const root = http.get(`${BASE_URL}/`);
+  check(root, { "GET / status < 500": (r) => r.status < 500 });
+
+  // Endpoint Prometheus expose par le backend.
+  const metrics = http.get(`${BASE_URL}/metrics`);
+  check(metrics, { "GET /metrics status 200": (r) => r.status === 200 });
+
+  // Endpoint data public.
+  const sales = http.get(`${BASE_URL}/api/v1/data/sales-metrics`);
+  check(sales, {
+    "GET /api/v1/data/sales-metrics status < 500": (r) => r.status < 500,
+  });
+
+  // Petite pause entre deux iterations utilisateur.
+  sleep(0.5);
+}

--- a/load-tests/k6/test_charge_02_charge_nominale_mixte.js
+++ b/load-tests/k6/test_charge_02_charge_nominale_mixte.js
@@ -1,0 +1,55 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+// URL cible de l'API (surchargeable via -e BASE_URL=...).
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8000";
+
+// Scenario nominal: montee en charge, plateau, puis descente.
+export const options = {
+  stages: [
+    { duration: "2m", target: 10 },
+    { duration: "6m", target: 25 },
+    { duration: "2m", target: 0 },
+  ],
+  thresholds: {
+    // Seuils permissifs pour un test mixte (certains endpoints peuvent repondre 4xx).
+    http_req_failed: ["rate<0.20"],
+    http_req_duration: ["p(95)<1500"],
+  },
+};
+
+// Entetes JSON reutilises pour les endpoints POST.
+const defaultHeaders = { "Content-Type": "application/json" };
+
+export default function () {
+  // Batch pour simuler un trafic mixte representatif de l'app.
+  const responses = http.batch([
+    ["GET", `${BASE_URL}/`, null, null],
+    ["GET", `${BASE_URL}/api/v1/data/sales-metrics`, null, null],
+    [
+      "POST",
+      `${BASE_URL}/api/v1/orders`,
+      JSON.stringify({ items: [] }),
+      { headers: defaultHeaders },
+    ],
+    [
+      "POST",
+      `${BASE_URL}/api/v1/payments`,
+      JSON.stringify({
+        order_id: "00000000-0000-0000-0000-000000000000",
+        simulate_scenario: "auto",
+        processing_delay_ms: 100,
+      }),
+      { headers: defaultHeaders },
+    ],
+  ]);
+
+  // Verifications minimales: l'API doit repondre sans erreurs serveur massives.
+  check(responses[0], { "GET / status < 500": (r) => r.status < 500 });
+  check(responses[1], { "GET sales-metrics status < 500": (r) => r.status < 500 });
+  check(responses[2], { "POST /orders repond": (r) => r.status >= 200 && r.status < 500 });
+  check(responses[3], { "POST /payments repond": (r) => r.status >= 200 && r.status < 500 });
+
+  // Pause courte entre deux iterations utilisateur.
+  sleep(0.3);
+}

--- a/load-tests/k6/test_charge_03_stress_paiements_5xx.js
+++ b/load-tests/k6/test_charge_03_stress_paiements_5xx.js
@@ -1,0 +1,110 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+// URL cible de l'API (surchargeable via -e BASE_URL=...).
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8000";
+// Credentials et produit de test (facultatifs mais recommandes pour generer de vrais 5xx).
+const EMAIL = __ENV.K6_CLIENT_EMAIL || "";
+const PASSWORD = __ENV.K6_CLIENT_PASSWORD || "";
+const PRODUCT_ID = __ENV.K6_PRODUCT_ID || "";
+
+// Scenario stress oriente paiements: palier principal de 10 minutes.
+export const options = {
+  stages: [
+    { duration: "2m", target: 5 },
+    { duration: "10m", target: 20 },
+    { duration: "3m", target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ["rate<0.80"],
+    http_req_duration: ["p(95)<2500"],
+  },
+};
+
+// Authentifie un utilisateur client et retourne le header Bearer.
+function login(email, password) {
+  const payload = `username=${encodeURIComponent(email)}&password=${encodeURIComponent(password)}`;
+  const headers = { "Content-Type": "application/x-www-form-urlencoded" };
+  const res = http.post(`${BASE_URL}/api/v1/auth/login`, payload, { headers });
+  if (res.status !== 200) return null;
+  const token = res.json("access_token");
+  return token ? `Bearer ${token}` : null;
+}
+
+// Cree une commande minimale afin d'avoir un order_id valide pour le paiement.
+function createOrder(authHeader, productId) {
+  const res = http.post(
+    `${BASE_URL}/api/v1/orders`,
+    JSON.stringify({
+      items: [{ product_id: productId, quantity: 1 }],
+    }),
+    {
+      headers: {
+        Authorization: authHeader,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  if (res.status !== 201) return null;
+  return res.json("id");
+}
+
+export default function () {
+  // Mode degrade sans credentials: envoie quand meme du trafic, mais souvent en 401.
+  if (!EMAIL || !PASSWORD || !PRODUCT_ID) {
+    const fallback = http.post(
+      `${BASE_URL}/api/v1/payments`,
+      JSON.stringify({
+        order_id: "00000000-0000-0000-0000-000000000000",
+        simulate_scenario: "provider_timeout",
+        processing_delay_ms: 300,
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+    check(fallback, { "fallback payments repond": (r) => r.status >= 200 && r.status < 500 });
+    sleep(0.2);
+    return;
+  }
+
+  // 1) Login.
+  const authHeader = login(EMAIL, PASSWORD);
+  if (!authHeader) {
+    sleep(0.2);
+    return;
+  }
+
+  // 2) Creation de commande.
+  const orderId = createOrder(authHeader, PRODUCT_ID);
+  if (!orderId) {
+    sleep(0.2);
+    return;
+  }
+
+  // 3) Paiement force en erreur technique (503/504) pour tester l'alerte SRE.
+  const scenario = Math.random() > 0.5 ? "provider_timeout" : "network_error";
+  const payment = http.post(
+    `${BASE_URL}/api/v1/payments`,
+    JSON.stringify({
+      order_id: orderId,
+      payment_method: "card",
+      idempotency_key: `${__VU}-${__ITER}-${Date.now()}`,
+      simulate_scenario: scenario,
+      processing_delay_ms: 300,
+    }),
+    {
+      headers: {
+        Authorization: authHeader,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  // On accepte 200 ou 5xx selon les conditions metier/transitions d'etat.
+  check(payment, {
+    "payment stress repond": (r) => r.status >= 200 && r.status < 600,
+    "payment stress genere 5xx de temps en temps": (r) => r.status === 503 || r.status === 504 || r.status === 200,
+  });
+
+  // Pause courte pour maintenir une pression soutenue.
+  sleep(0.2);
+}


### PR DESCRIPTION
## Resume
- Ajout d'une suite de tests de charge k6 pour le Sprint 4:
  - smoke endpoints publics
  - charge nominale mixte
  - stress paiements techniques 5xx
- Ajout d'une documentation de campagne de charge et de verification des alertes SRE.
- Mise a jour des references de scripts dans la documentation.

## Pourquoi
- Valider la tenue de l'API sous charge.
- Verifier que les metriques SRE evoluent correctement dans Prometheus/Grafana.
- Verifier l'efficacite du monitoring/alerting.

## Perimetre
- [ ] Backend
- [ ] Frontend
- [ ] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] Verifications locales executees
- [ ] CI au vert
- [x] Aucun secret commit

## Sprint / Story
- Sprint : 4
- Story/Tache : FEAT4.1 Tests de charge (k6/JMeter) et verification des alertes SRE

## Notes pour la review
- Points a verifier en priorite :
  - scripts dans `load-tests/k6/`
  - doc de campagne `docs/sprint4_load_tests_alerts.md`
  - cohérence des noms dans `load-tests/k6/README.md`
  - impact dashboards:
    - disponibilite API
    - latence p90 commandes
    - taux erreurs paiements (5xx)
  - verification alertes Prometheus sur `/alerts` selon la duree du test
