### PR TITLE
feat #24: ajouter les manifests Kubernetes pour le scaling du backend…

### DIFF
--- a/docs/sprint4_kubernetes_scaling.md
+++ b/docs/sprint4_kubernetes_scaling.md
@@ -1,0 +1,127 @@
+# Sprint 4 - Ajustement du scaling Kubernetes
+
+## Objectif
+Ajuster le scaling Kubernetes selon les resultats de charge Sprint 4 afin d'optimiser le compromis performance/cout tout en respectant les objectifs SRE.
+
+## Livrables
+- Manifests Kubernetes ajoutes dans `k8s/`:
+  - `namespace.yaml`
+  - `backend-configmap.yaml`
+  - `backend-secret.example.yaml`
+  - `backend-deployment.yaml`
+  - `backend-service.yaml`
+  - `backend-compat-service.yaml`
+  - `backend-hpa.yaml`
+  - `frontend-deployment.yaml`
+  - `frontend-service.yaml`
+  - `kustomization.yaml`
+
+## Decisions de scaling (backend)
+Sur la base des tests k6 (smoke, nominal, stress):
+1. **Replicas de base**
+- `replicas: 2` sur le backend pour absorber une charge normale sans cold-start.
+
+2. **HPA backend**
+- `minReplicas: 2`
+- `maxReplicas: 6`
+- cibles:
+  - CPU `averageUtilization: 65`
+  - memoire `averageUtilization: 75`
+
+3. **Comportement HPA**
+- Scale-up rapide:
+  - `+100%` max par minute.
+- Scale-down plus prudent:
+  - fenetre de stabilisation `300s`
+  - `-30%` max par minute.
+
+Ce comportement evite l'effet "yoyo" tout en reagissant vite en pic.
+
+## Ressources backend
+- requests:
+  - CPU `250m`
+  - RAM `256Mi`
+- limits:
+  - CPU `1000m`
+  - RAM `1Gi`
+
+## Ressources frontend
+- replicas: `2`
+- requests:
+  - CPU `100m`
+  - RAM `128Mi`
+- limits:
+  - CPU `500m`
+  - RAM `512Mi`
+
+## Application des manifests
+Prerequis cluster:
+- metrics-server installe (obligatoire pour HPA CPU/memoire).
+- acces image GHCR configure.
+
+Commande:
+```bash
+kubectl create namespace marketplace-staging
+kubectl -n marketplace-staging create secret generic marketplace-backend-secret \
+  --from-literal=POSTGRES_USER=marketplace_user \
+  --from-literal=POSTGRES_PASSWORD=changeme \
+  --from-literal=SECRET_KEY=ta_super_cle
+kubectl apply -k k8s
+```
+
+Note:
+- `backend-secret.example.yaml` est un template documente, a ne pas appliquer tel quel en environnement reel.
+- `backend-compat-service.yaml` ajoute un alias DNS `backend` pour la compatibilite avec `frontend/nginx.conf` (proxy `http://backend:8000`).
+
+## Verification
+```bash
+kubectl -n marketplace-staging get pods
+kubectl -n marketplace-staging get deploy
+kubectl -n marketplace-staging get svc
+kubectl -n marketplace-staging get hpa
+kubectl -n marketplace-staging describe hpa marketplace-backend-hpa
+```
+
+Pendant un test k6:
+```bash
+kubectl -n marketplace-staging get hpa -w
+kubectl -n marketplace-staging get pods -w
+kubectl -n marketplace-staging top pods
+```
+
+## Resultats observes (validation)
+Execution reelle sur Minikube:
+1. Etat stable avant charge:
+- backend `2/2` pods `Running`
+- frontend `2/2` pods `Running`
+- HPA backend actif (`min=2`, `max=6`)
+
+2. Pendant charge k6:
+- HPA observe:
+  - `cpu: 84%/65%` puis `cpu: 163%/65%`
+  - `REPLICAS: 2 -> 3 -> 5`
+- Pods backend observes:
+  - creation dynamique de nouveaux pods (`Pending` -> `ContainerCreating` -> `Running`)
+
+3. Apres charge:
+- HPA observe:
+  - baisse CPU a `2%/65%`
+  - `REPLICAS: 5 -> 3 -> 2`
+- Le retour a 2 est progressif grace a `stabilizationWindowSeconds: 300` (anti-yoyo).
+
+## Lecture des sorties kubectl
+- `TARGETS cpu: X/65%`: charge CPU actuelle (X) comparee a la cible HPA (65%).
+- `TARGETS memory: Y/75%`: charge memoire actuelle (Y) comparee a la cible HPA (75%).
+- `REPLICAS`: nombre de pods backend actuellement demandes par le HPA.
+- `MINPODS/MAXPODS`: bornes de scaling autorisees (`2..6`).
+
+Definition rapide:
+- Un pod = une instance d'execution de l'application (conteneur).
+- Si charge > cible, Kubernetes ajoute des pods.
+- Si charge redescend, Kubernetes retire des pods pour limiter le cout.
+
+## Criteres de validation
+1. Le backend scale entre 2 et 6 replicas selon la charge.
+2. Le scale-up se declenche sur pic soutenu.
+3. Le scale-down est progressif apres retour a la normale.
+4. Les indicateurs SRE restent dans des bornes acceptables (latence/erreurs).

--- a/k8s/backend-compat-service.yaml
+++ b/k8s/backend-compat-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: marketplace-staging
+  labels:
+    app: marketplace-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: marketplace-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/k8s/backend-configmap.yaml
+++ b/k8s/backend-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: marketplace-backend-config
+  namespace: marketplace-staging
+data:
+  POSTGRES_HOST: "postgresql.default.svc.cluster.local"
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: "marketplace_db"
+  ACCESS_TOKEN_EXPIRE_MINUTES: "10080"

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-backend
+  namespace: marketplace-staging
+  labels:
+    app: marketplace-backend
+spec:
+  # Base de replicas choisie apres tests de charge Sprint 4.
+  replicas: 2
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: marketplace-backend
+  template:
+    metadata:
+      labels:
+        app: marketplace-backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/thomassanna/m1de-marketplace-locale-intelligente/backend:dev-latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: marketplace-backend-config
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: marketplace-backend-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: marketplace-backend-config
+                  key: POSTGRES_DB
+            - name: ACCESS_TOKEN_EXPIRE_MINUTES
+              valueFrom:
+                configMapKeyRef:
+                  name: marketplace-backend-config
+                  key: ACCESS_TOKEN_EXPIRE_MINUTES
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: marketplace-backend-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: marketplace-backend-secret
+                  key: POSTGRES_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: marketplace-backend-secret
+                  key: SECRET_KEY
+            - name: DATABASE_URL
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@$(POSTGRES_HOST):$(POSTGRES_PORT)/$(POSTGRES_DB)
+          # Requests/limits ajustes pour laisser de la marge sous charge.
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: http
+            initialDelaySeconds: 8
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 2
+            failureThreshold: 3

--- a/k8s/backend-hpa.yaml
+++ b/k8s/backend-hpa.yaml
@@ -1,0 +1,38 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: marketplace-backend-hpa
+  namespace: marketplace-staging
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: marketplace-backend
+  minReplicas: 2
+  maxReplicas: 6
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 30
+          periodSeconds: 60
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 65
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75

--- a/k8s/backend-secret.example.yaml
+++ b/k8s/backend-secret.example.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: marketplace-backend-secret
+  namespace: marketplace-staging
+type: Opaque
+stringData:
+  POSTGRES_USER: "marketplace_user"
+  POSTGRES_PASSWORD: "change_me"
+  SECRET_KEY: "change_me_super_secret_key"

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketplace-backend
+  namespace: marketplace-staging
+  labels:
+    app: marketplace-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: marketplace-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: marketplace-frontend
+  namespace: marketplace-staging
+  labels:
+    app: marketplace-frontend
+spec:
+  replicas: 2
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: marketplace-frontend
+  template:
+    metadata:
+      labels:
+        app: marketplace-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/thomassanna/m1de-marketplace-locale-intelligente/frontend:dev-latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 2
+            failureThreshold: 3

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: marketplace-frontend
+  namespace: marketplace-staging
+  labels:
+    app: marketplace-frontend
+spec:
+  type: LoadBalancer
+  selector:
+    app: marketplace-frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: marketplace-staging
+resources:
+  - namespace.yaml
+  - backend-configmap.yaml
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - backend-compat-service.yaml
+  - backend-hpa.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: marketplace-staging


### PR DESCRIPTION
## Resume
- Ajout de la stack Kubernetes pour le scaling Sprint 4 (`k8s/`).
- Mise en place du HPA backend (`min=2`, `max=6`, CPU 65%, memoire 75%, scale-down stabilise).
- Ajout du service de compatibilite `backend` pour corriger le proxy frontend vers `http://backend:8000`.
- Mise a jour de la doc de validation: `docs/sprint4_kubernetes_scaling.md`.

## Pourquoi
- Ajustement du scaling Kubernetes selon les resultats de charge.
- Permet d'optimiser performance/cout avec autoscaling backend.

## Perimetre
- [x] Backend
- [x] Frontend
- [ ] Data
- [x] DevOps/Infra
- [x] Documentation

## Validation
- [x] Verifications locales executees
- [x] CI au vert
- [x] Aucun secret commit

## Sprint / Story
- Sprint : Sprint 4
- Story/Tache : Ajustement du scaling Kubernetes selon resultats de charge

## Notes pour la review
- Points a verifier en priorite :
  - HPA backend bien configure: `minReplicas: 2`, `maxReplicas: 6`, CPU `65%`, memoire `75%`.
  - Presence du service `backend` (compatibilite frontend nginx).
  - Validation observee sous charge: `REPLICAS 2 -> 3 -> 5 -> 3 -> 2`.
  - Aucun secret reel versionne (`backend-secret.example.yaml` reste un template).
