### PR TITLE
feat(frontend): interface producteur (dashboard, création/édition/...)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,12 +9,29 @@ import ProducteursPage from './pages/ProducteursPage';
 import CommandesPage from './pages/CommandesPage';
 import CommandeDetailPage from './pages/CommandeDetailPage';
 import ProducerDetailPage from './pages/ProducerDetailPage';
+import ProducerDashboardPage from './pages/ProducerDashboardPage';
+import ProducerProductFormPage from './pages/ProducerProductFormPage';
 
-// Route protégée : redirige vers /login si non connecté
+function FullPageSpinner() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="animate-spin h-8 w-8 border-4 border-primary-600 border-t-transparent rounded-full" />
+    </div>
+  );
+}
+
 function PrivateRoute({ children }) {
   const { user, loading } = useAuth();
-  if (loading) return <div className="min-h-screen flex items-center justify-center"><div className="animate-spin h-8 w-8 border-4 border-primary-600 border-t-transparent rounded-full" /></div>;
+  if (loading) return <FullPageSpinner />;
   return user ? children : <Navigate to="/login" replace />;
+}
+
+function ProducerRoute({ children }) {
+  const { user, loading } = useAuth();
+  if (loading) return <FullPageSpinner />;
+  if (!user) return <Navigate to="/login" replace />;
+  if (user.role !== "producer") return <Navigate to="/catalogue" replace />;
+  return children;
 }
 
 export default function App() {
@@ -29,10 +46,15 @@ export default function App() {
         <Route path="/producteurs" element={<ProducteursPage />} />
         <Route path="/producteurs/:id" element={<ProducerDetailPage />} />
 
-        {/* Pages protégées */}
+        {/* Pages protégées (utilisateur connecté) */}
         <Route path="/panier" element={<PrivateRoute><PanierPage /></PrivateRoute>} />
         <Route path="/mes-commandes" element={<PrivateRoute><CommandesPage /></PrivateRoute>} />
         <Route path="/commandes/:id" element={<PrivateRoute><CommandeDetailPage /></PrivateRoute>} />
+
+        {/* Pages producteur */}
+        <Route path="/dashboard" element={<ProducerRoute><ProducerDashboardPage /></ProducerRoute>} />
+        <Route path="/dashboard/produits/new" element={<ProducerRoute><ProducerProductFormPage /></ProducerRoute>} />
+        <Route path="/dashboard/produits/:id/edit" element={<ProducerRoute><ProducerProductFormPage /></ProducerRoute>} />
 
         {/* Fallback */}
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/products.js
+++ b/frontend/src/api/products.js
@@ -27,3 +27,13 @@ export const getProducers = (params = {}) =>
 // GET /api/v1/producers/:id/products
 export const getProducerProducts = (producerId) =>
   apiClient.get(`/api/v1/producers/${producerId}/products`);
+
+// POST /api/v1/producers  [Auth Producer]
+export const createProducerProfile = (producerData) =>
+  apiClient.post("/api/v1/producers", producerData);
+
+// Helper : retrouve le producteur lié au user connecté (via user_id)
+export const getMyProducer = async (userId) => {
+  const res = await getProducers({ limit: 1000 });
+  return res.data.find((p) => p.user_id === userId) || null;
+};

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -34,9 +34,14 @@ export default function Navbar() {
             <Link to="/producteurs" className="text-sm text-gray-600 hover:text-primary-600 font-medium transition-colors">
               Producteurs
             </Link>
-            {user && (
+            {user && user.role === "client" && (
               <Link to="/mes-commandes" className="text-sm text-gray-600 hover:text-primary-600 font-medium transition-colors">
                 Mes commandes
+              </Link>
+            )}
+            {user && user.role === "producer" && (
+              <Link to="/dashboard" className="text-sm text-gray-600 hover:text-primary-600 font-medium transition-colors">
+                Mon Dashboard
               </Link>
             )}
           </nav>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -23,7 +23,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       const user = await login(form.email, form.password);
-      navigate(user.role === "producer" ? "/catalogue" : "/catalogue");
+      navigate(user.role === "producer" ? "/dashboard" : "/catalogue");
     } catch (err) {
       setError(getErrorMessage(err, "Email ou mot de passe incorrect."));
     } finally {

--- a/frontend/src/pages/ProducerDashboardPage.jsx
+++ b/frontend/src/pages/ProducerDashboardPage.jsx
@@ -1,0 +1,201 @@
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Plus, Edit2, Trash2, Package, AlertCircle, MapPin } from "lucide-react";
+import { getMyProducer, getProducerProducts, deleteProduct } from "../api/products";
+import { useAuth } from "../context/AuthContext";
+import { Button } from "../components/ui/Button";
+import { Badge } from "../components/ui/Badge";
+import ErrorState from "../components/ui/ErrorState";
+import Layout from "../components/Layout";
+import { getCategoryImage } from "../lib/categoryImages";
+import { getErrorMessage } from "../api/errors";
+
+export default function ProducerDashboardPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [producer, setProducer] = useState(null);
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [deletingId, setDeletingId] = useState(null);
+
+  const fetchData = useCallback(async () => {
+    if (!user) return;
+    setLoading(true);
+    setError("");
+    try {
+      const myProducer = await getMyProducer(user.id);
+      if (!myProducer) {
+        setError("Aucun profil producteur n'est associé à votre compte. Contactez l'administrateur.");
+        setLoading(false);
+        return;
+      }
+      setProducer(myProducer);
+      const res = await getProducerProducts(myProducer.id);
+      setProducts(res.data);
+    } catch (err) {
+      setError(getErrorMessage(err, "Impossible de charger votre boutique."));
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const handleDelete = async (productId) => {
+    if (!window.confirm("Voulez-vous vraiment désactiver ce produit ?")) return;
+    setDeletingId(productId);
+    try {
+      await deleteProduct(productId);
+      setProducts((prev) => prev.filter((p) => p.id !== productId));
+    } catch (err) {
+      alert(getErrorMessage(err, "Impossible de supprimer ce produit."));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="space-y-4">
+          <div className="h-10 bg-gray-200 rounded animate-pulse w-64" />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="bg-white rounded-2xl border border-gray-200 h-24 animate-pulse" />
+            ))}
+          </div>
+          <div className="bg-white rounded-2xl border border-gray-200 h-64 animate-pulse" />
+        </div>
+      </Layout>
+    );
+  }
+
+  if (error) {
+    return (
+      <Layout>
+        <ErrorState message={error} onRetry={fetchData} />
+      </Layout>
+    );
+  }
+
+  const activeCount = products.filter((p) => p.is_active).length;
+  const lowStockCount = products.filter((p) => p.is_active && Number(p.stock_quantity) < 5).length;
+
+  return (
+    <Layout>
+      {/* En-tête */}
+      <div className="flex items-start justify-between flex-wrap gap-4 mb-8">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-1">Mon Dashboard</h1>
+          {producer && (
+            <p className="text-gray-500 flex items-center gap-1 text-sm">
+              <MapPin className="h-4 w-4" />
+              {producer.farm_name} — {producer.location_city}, {producer.location_region}
+            </p>
+          )}
+        </div>
+        <Button onClick={() => navigate("/dashboard/produits/new")} className="gap-2">
+          <Plus className="h-4 w-4" /> Ajouter un produit
+        </Button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+        <div className="bg-white rounded-2xl border border-gray-200 p-5">
+          <div className="flex items-center gap-3">
+            <div className="bg-primary-50 rounded-xl p-2.5">
+              <Package className="h-5 w-5 text-primary-600" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-900">{products.length}</p>
+              <p className="text-xs text-gray-500">Produits au catalogue</p>
+            </div>
+          </div>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-200 p-5">
+          <div className="flex items-center gap-3">
+            <div className="bg-green-50 rounded-xl p-2.5">
+              <Package className="h-5 w-5 text-green-600" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-900">{activeCount}</p>
+              <p className="text-xs text-gray-500">Produits actifs</p>
+            </div>
+          </div>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-200 p-5">
+          <div className="flex items-center gap-3">
+            <div className="bg-orange-50 rounded-xl p-2.5">
+              <AlertCircle className="h-5 w-5 text-orange-600" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-900">{lowStockCount}</p>
+              <p className="text-xs text-gray-500">Stock faible (&lt; 5)</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Liste produits */}
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Mes produits</h2>
+
+      {products.length === 0 ? (
+        <div className="text-center py-16 bg-white rounded-2xl border border-gray-200">
+          <Package className="h-16 w-16 text-gray-200 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-gray-700 mb-2">Aucun produit pour le moment</h3>
+          <p className="text-gray-500 mb-6">Commencez par ajouter votre premier produit au catalogue</p>
+          <Button onClick={() => navigate("/dashboard/produits/new")} className="gap-2">
+            <Plus className="h-4 w-4" /> Ajouter un produit
+          </Button>
+        </div>
+      ) : (
+        <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
+          <div className="divide-y divide-gray-100">
+            {products.map((product) => (
+              <div key={product.id} className="p-4 flex items-center gap-4 hover:bg-gray-50 transition-colors">
+                <div className="h-14 w-14 rounded-xl overflow-hidden flex-shrink-0">
+                  <img
+                    src={getCategoryImage(product.category)}
+                    alt={product.name}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <h3 className="font-semibold text-gray-900 text-sm truncate">{product.name}</h3>
+                    {!product.is_active && <Badge variant="default">Inactif</Badge>}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    {product.category} · Stock : {Number(product.stock_quantity)} {product.unit}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="font-bold text-primary-700">{Number(product.price).toFixed(2)} €</p>
+                  <p className="text-xs text-gray-400">/ {product.unit}</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => navigate(`/dashboard/produits/${product.id}/edit`)}
+                    className="p-2 text-gray-400 hover:text-primary-600 transition-colors"
+                    title="Modifier"
+                  >
+                    <Edit2 className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(product.id)}
+                    disabled={deletingId === product.id}
+                    className="p-2 text-gray-400 hover:text-red-600 transition-colors disabled:opacity-30"
+                    title="Désactiver"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/frontend/src/pages/ProducerProductFormPage.jsx
+++ b/frontend/src/pages/ProducerProductFormPage.jsx
@@ -1,0 +1,253 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ArrowLeft, Save } from "lucide-react";
+import { getProductById, createProduct, updateProduct } from "../api/products";
+import { Button } from "../components/ui/Button";
+import { Input } from "../components/ui/Input";
+import ErrorState from "../components/ui/ErrorState";
+import Layout from "../components/Layout";
+import { getErrorMessage } from "../api/errors";
+
+const CATEGORIES = [
+  { value: "fruits", label: "Fruits" },
+  { value: "legumes", label: "Légumes" },
+  { value: "viandes", label: "Viandes" },
+  { value: "poissons", label: "Poissons" },
+  { value: "produits_laitiers", label: "Produits laitiers" },
+  { value: "epicerie", label: "Épicerie" },
+  { value: "boissons", label: "Boissons" },
+  { value: "autres", label: "Autres" },
+];
+
+const UNITS = [
+  { value: "piece", label: "Pièce" },
+  { value: "kg", label: "Kilogramme" },
+  { value: "g", label: "Gramme" },
+  { value: "litre", label: "Litre" },
+  { value: "bouquet", label: "Bouquet" },
+  { value: "boite", label: "Boîte" },
+];
+
+const EMPTY_FORM = {
+  name: "",
+  description: "",
+  category: "fruits",
+  price: "",
+  stock_quantity: "",
+  unit: "piece",
+  is_active: true,
+};
+
+export default function ProducerProductFormPage() {
+  const { id } = useParams();
+  const isEdit = Boolean(id);
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [loading, setLoading] = useState(isEdit);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    if (!isEdit) return;
+    setLoading(true);
+    getProductById(id)
+      .then((res) => {
+        const p = res.data;
+        setForm({
+          name: p.name,
+          description: p.description || "",
+          category: p.category,
+          price: String(p.price),
+          stock_quantity: String(p.stock_quantity),
+          unit: p.unit,
+          is_active: p.is_active,
+        });
+      })
+      .catch((err) => setLoadError(getErrorMessage(err, "Impossible de charger ce produit.")))
+      .finally(() => setLoading(false));
+  }, [id, isEdit]);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    try {
+      const payload = {
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        category: form.category,
+        price: Number(form.price),
+        stock_quantity: Number(form.stock_quantity),
+        unit: form.unit,
+      };
+      if (isEdit) {
+        payload.is_active = form.is_active;
+        await updateProduct(id, payload);
+      } else {
+        await createProduct(payload);
+      }
+      navigate("/dashboard");
+    } catch (err) {
+      setError(getErrorMessage(err, "Impossible d'enregistrer le produit."));
+      setSubmitting(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <Layout>
+        <div className="max-w-md mx-auto">
+          <ErrorState message={loadError} />
+          <div className="text-center">
+            <Button variant="outline" onClick={() => navigate("/dashboard")}>
+              <ArrowLeft className="h-4 w-4 mr-2" /> Retour au dashboard
+            </Button>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Layout>
+        <div className="max-w-2xl mx-auto space-y-4">
+          <div className="h-8 bg-gray-200 rounded animate-pulse w-48" />
+          <div className="bg-white rounded-2xl border border-gray-200 h-96 animate-pulse" />
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-2xl mx-auto">
+        <button
+          onClick={() => navigate("/dashboard")}
+          className="flex items-center gap-2 text-sm text-gray-500 hover:text-primary-600 mb-6 transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" /> Retour au dashboard
+        </button>
+
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">
+          {isEdit ? "Modifier le produit" : "Ajouter un produit"}
+        </h1>
+
+        <form onSubmit={handleSubmit} className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
+          <Input
+            label="Nom du produit"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            placeholder="Ex : Pommes Golden bio"
+            required
+            maxLength={200}
+          />
+
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-gray-700">Description (optionnel)</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              rows={3}
+              placeholder="Origine, mode de production, conseils..."
+              className="px-3 py-2 border border-gray-300 rounded-lg text-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 resize-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-gray-700">Catégorie</label>
+              <select
+                name="category"
+                value={form.category}
+                onChange={handleChange}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 bg-white"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-gray-700">Unité</label>
+              <select
+                name="unit"
+                value={form.unit}
+                onChange={handleChange}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 bg-white"
+              >
+                {UNITS.map((u) => (
+                  <option key={u.value} value={u.value}>{u.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Input
+              label="Prix (€)"
+              name="price"
+              type="number"
+              step="0.01"
+              min="0"
+              value={form.price}
+              onChange={handleChange}
+              placeholder="0.00"
+              required
+            />
+            <Input
+              label="Stock disponible"
+              name="stock_quantity"
+              type="number"
+              step="0.001"
+              min="0"
+              value={form.stock_quantity}
+              onChange={handleChange}
+              placeholder="0"
+              required
+            />
+          </div>
+
+          {isEdit && (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                name="is_active"
+                checked={form.is_active}
+                onChange={handleChange}
+                className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              />
+              <span className="text-sm text-gray-700">Produit visible au catalogue</span>
+            </label>
+          )}
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 text-red-700 text-sm px-4 py-3 rounded-lg">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-3 pt-2 border-t border-gray-100">
+            <Button type="button" variant="ghost" onClick={() => navigate("/dashboard")}>
+              Annuler
+            </Button>
+            <Button type="submit" disabled={submitting} className="gap-2">
+              <Save className="h-4 w-4" />
+              {submitting ? "Enregistrement..." : isEdit ? "Enregistrer" : "Créer le produit"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION

- Nouvelle page ProducerDashboardPage (/dashboard) : liste des produits du producteur connecté avec stats (total, actifs, stock faible) et actions rapides
- Nouvelle page ProducerProductFormPage (/dashboard/produits/new et /dashboard/produits/:id/edit) : formulaire création + édition avec sélecteurs catégorie/unité, gestion stock et activation
- Suppression/désactivation de produit avec confirmation
- Composant ProducerRoute pour protéger les routes réservées aux producteurs (redirect /catalogue si rôle != producer)
- Helper getMyProducer(userId) côté API pour retrouver le producer du user connecté
- Login producteur redirige maintenant vers /dashboard (au lieu de /catalogue)
- Navbar : lien "Mon Dashboard" affiché pour producteur, "Mes commandes" pour client

